### PR TITLE
Use ACPu storage for monotonic counters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 composer.lock
 coverage.xml
 vendor/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ WORKDIR /app
 # Copy project files
 COPY . .
 
+# Register volumes
+VOLUME /app
+VOLUME /app/vendor
+
 # Enable APCu for CLI
 RUN echo "apc.enable_cli=1" >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM php:8.2-cli
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    unzip \
+    libzip-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install PHP extensions
+RUN pecl install apcu \
+    && docker-php-ext-enable apcu
+
+# Install Composer
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+# Set working directory
+WORKDIR /app
+
+# Copy project files
+COPY . .
+
+# Enable APCu for CLI
+RUN echo "apc.enable_cli=1" >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini
+
+# Install dependencies
+RUN composer install
+
+# Command to run tests
+CMD ["vendor/bin/phpunit"]

--- a/README.md
+++ b/README.md
@@ -175,6 +175,15 @@ $uuid_version = UUID::getVersion('2140a926-4a47-465c-b622-4571ad9bb378');
 var_dump($uuid_version); // int(4)
 ```
 
+### Development
+
+Add Docker setup to run tests without locally installed PHP.
+
+```bash
+docker build -t uuid-php-test .
+docker run --rm uuid-php-test
+```
+
 ## UUIDv6 Field and Bit Layout
 
 ```

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Add Docker setup to run tests without locally installed PHP.
 
 ```bash
 docker build -t uuid-php-test .
-docker run --rm uuid-php-test
+docker run --rm -it -v $(pwd):/app uuid-php-test vendor/bin/phpunit
 ```
 
 ## UUIDv6 Field and Bit Layout

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^8.1"
+        "php": "^8.1",
+        "ext-apcu": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0"

--- a/src/UUID.php
+++ b/src/UUID.php
@@ -80,23 +80,16 @@ class UUID
     . '\-?([0-9a-f]{4})\-?([0-9a-f]{4})\-?([0-9a-f]{12})(?(1)\}|)$/i';
 
     /** @internal */
-    private static $unixts = 0;
-
-    /** @internal */
-    private static $subsec = 0;
-
-    /** @internal */
-    private static $unixts_ms = 0;
-
-    /** @internal */
     private static function getUnixTimeSubsec(): array
     {
         $timestamp = microtime(false);
         $unixts = intval(substr($timestamp, 11), 10);
         $subsec = intval(substr($timestamp, 2, 7), 10);
-        if (self::$unixts > $unixts || self::$unixts === $unixts && self::$subsec >= $subsec) {
-            $unixts = self::$unixts;
-            $subsec = self::$subsec;
+        $last_unixts = apcu_fetch('unixts');
+        $last_subsec = apcu_fetch('subsec');
+        if ($last_unixts > $unixts || ($last_unixts === $unixts && $last_subsec >= $subsec)) {
+            $unixts = $last_unixts;
+            $subsec = $last_subsec;
             if ($subsec >= self::SUBSEC_RANGE - 1) {
                 $subsec = 0;
                 $unixts++;
@@ -104,8 +97,8 @@ class UUID
                 $subsec++;
             }
         }
-        self::$unixts = $unixts;
-        self::$subsec = $subsec;
+        apcu_store('unixts', $unixts);
+        apcu_store('subsec', $subsec);
         return [$unixts, $subsec];
     }
 
@@ -115,10 +108,11 @@ class UUID
         $timestamp = microtime(false);
         $unixts = intval(substr($timestamp, 11), 10);
         $unixts_ms = $unixts * 1000 + intval(substr($timestamp, 2, 3), 10);
-        if (self::$unixts_ms >= $unixts_ms) {
-            $unixts_ms = self::$unixts_ms + 1;
+        $last_unixts_ms = apcu_fetch('unixts_ms');
+        if ($last_unixts_ms >= $unixts_ms) {
+            $unixts_ms = $last_unixts_ms + 1;
         }
-        self::$unixts_ms = $unixts_ms;
+        apcu_store('unixts_ms', $unixts_ms);
         return $unixts_ms;
     }
 

--- a/src/UUID.php
+++ b/src/UUID.php
@@ -83,8 +83,8 @@ class UUID
     private static function getUnixTimeSubsec(): array
     {
         $timestamp = microtime(false);
-        $unixts = intval(substr($timestamp, 11), 10);
-        $subsec = intval(substr($timestamp, 2, 7), 10);
+        $unixts = (int)substr($timestamp, 11);
+        $subsec = (int)substr($timestamp, 2, 7);
         $last_unixts = apcu_fetch('unixts');
         $last_subsec = apcu_fetch('subsec');
         if ($last_unixts > $unixts || ($last_unixts === $unixts && $last_subsec >= $subsec)) {
@@ -106,8 +106,8 @@ class UUID
     private static function getUnixTimeMs(): int
     {
         $timestamp = microtime(false);
-        $unixts = intval(substr($timestamp, 11), 10);
-        $unixts_ms = $unixts * 1000 + intval(substr($timestamp, 2, 3), 10);
+        $unixts = (int)substr($timestamp, 11);
+        $unixts_ms = $unixts * 1000 + (int)substr($timestamp, 2, 3);
         $last_unixts_ms = apcu_fetch('unixts_ms');
         if ($last_unixts_ms >= $unixts_ms) {
             $unixts_ms = $last_unixts_ms + 1;
@@ -306,15 +306,15 @@ class UUID
                 $retval = '-';
                 $ts = abs($ts);
             }
-            $retval .= substr_replace(str_pad(strval($ts), 8, '0', \STR_PAD_LEFT), '.', -7, 0);
+            $retval .= substr_replace(str_pad((string)$ts, 8, '0', \STR_PAD_LEFT), '.', -7, 0);
         } elseif ($version === 7) {
             $unixts = hexdec(substr($timehex, 0, 13));
-            $retval = strval($unixts * self::V7_SUBSEC_RANGE);
+            $retval = (string)($unixts * self::V7_SUBSEC_RANGE);
             $retval = substr_replace(str_pad($retval, 8, '0', \STR_PAD_LEFT), '.', -7, 0);
         } elseif ($version === 8) {
             $unixts = hexdec(substr($timehex, 0, 13));
             $subsec = self::decodeSubsec((hexdec(substr($timehex, 13)) << 2) + (hexdec(substr($uuid, 16, 1)) & 0x03));
-            $retval = strval($unixts * self::V8_SUBSEC_RANGE + $subsec);
+            $retval = (string)($unixts * self::V8_SUBSEC_RANGE + $subsec);
             $retval = substr_replace(str_pad($retval, 8, '0', \STR_PAD_LEFT), '.', -7, 0);
         }
         return $retval;

--- a/tests/FutureTimeTest.php
+++ b/tests/FutureTimeTest.php
@@ -13,32 +13,16 @@ final class FutureTimeTest extends TestCase
 {
     protected function setUp(): void
     {
-        $a = new UUID();
-        $reflection = new \ReflectionClass($a);
-        $property = $reflection->getProperty('unixts');
-        $property->setAccessible(true);
-        $property->setValue($a, 9000000000);
-        $property = $reflection->getProperty('subsec');
-        $property->setAccessible(true);
-        $property->setValue($a, 9999990);
-        $property = $reflection->getProperty('unixts_ms');
-        $property->setAccessible(true);
-        $property->setValue($a, 9000000000090);
+        apcu_store('unixts', 9000000000);
+        apcu_store('subsec', 9999990);
+        apcu_store('unixts_ms', 9000000000090);
     }
 
     protected function tearDown(): void
     {
-        $a = new UUID();
-        $reflection = new \ReflectionClass($a);
-        $property = $reflection->getProperty('unixts');
-        $property->setAccessible(true);
-        $property->setValue($a, 0);
-        $property = $reflection->getProperty('subsec');
-        $property->setAccessible(true);
-        $property->setValue($a, 0);
-        $property = $reflection->getProperty('unixts_ms');
-        $property->setAccessible(true);
-        $property->setValue($a, 0);
+        apcu_delete('unixts');
+        apcu_delete('subsec');
+        apcu_delete('unixts_ms');
     }
 
     public function testFutureTimeVersion6()


### PR DESCRIPTION
This Pull Request addresses the issue of monotonic counters in multi-process environments (such as PHP-FPM):
- Moved timestamp state management from class static properties to APCu shared memory.
- Updated getUnixTimeSubsec() and getUnixTimeMs() to use apcu_fetch and apcu_store.
- This ensures that UUID versions 6, 7, and 8 maintain strict monotonicity across different PHP-FPM worker processes, preventing potential collisions or out-of-order sequences during high concurrency.
- Removed obsolete static properties: $unixts, $subsec, and $unixts_ms.